### PR TITLE
samtools view fastq updates

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -308,11 +308,14 @@ if (params.bam && params.bed && params.bai) {
         set val(interval_name), val(chrom), val(chromStart), val(chromEnd), file(bam), file(bai) from ch_bed_bam_bai
 
 	output:
-	set val(interval_name), file("*.fastq") into ch_intersected
+	set val(interval_name), file(fastq) into ch_intersected
 
 	script:
+	fastq = "${interval_name}.fastq.gz"
 	"""
-        samtools view -h $bam ${chrom}:${chromStart}-${chromEnd} | samtools fastq -o ${interval_name}.fastq 
+        samtools view -hu $bam '${chrom}:${chromStart}-${chromEnd}' \\
+		| samtools fastq -N - \\
+		| gzip -c > ${fastq}
         """
     }
     ch_intersected


### PR DESCRIPTION
Made a few changes to the `samtools_view_fastq` process:

### `-u` - Output uncompressed bam since piping to another samtools command

From [samtools view docs](http://www.htslib.org/doc/samtools-view.html):

> Output uncompressed BAM. This option saves time spent on compression/decompression and is thus preferred when the output is piped to another samtools command.


### Protect chromosomal region in quotes

The sequence names may contain weird characters so protect them in quotes so bash doesn't think they're some command

### Use stdout to write fastq

For some reason, for paired end reads, the `-o ${interval_name}.fastq` wasn't writing when the input was a paired-end bam, but `-o` gives this error on a paired-end bam:

```
(samtools) phoenix@lrrr:/mnt/data_lg/phoenix/predictorthologs/work/61/fd139477425c2ebd665a302e2bee1f$ samtools fastq -o test-o.fastq test.bam
fastq: invalid option -- 'o'
Usage: samtools fastq [options...] <in.bam>
Options:
  -0 FILE              write reads designated READ_OTHER to FILE
  -1 FILE              write reads designated READ1 to FILE
  -2 FILE              write reads designated READ2 to FILE
                       note: if a singleton file is specified with -s, only
```

They know that the multitude of ways to specify output is a problem .. see [samtools fastq BUGS](https://www.htslib.org/doc/samtools-fasta.html#BUGS) section.

### Add `-N` to specify R1 or R2 for all reads

From [samtools fastq docs](https://www.htslib.org/doc/samtools-fasta.html)

> Always add either '/1' or '/2' to the end of read names even when put into different files.


### Gzip output

Since there can be a ton of output files, gzip them to save space

# nf-core/predictorthologs pull request

Many thanks for contributing to nf-core/predictorthologs!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the [nf-core/predictorthologs branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/predictorthologs)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Documentation in `docs` is updated
- [ ] `CHANGELOG.md` is updated
- [ ] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/predictorthologs/tree/master/.github/CONTRIBUTING.md)