### PR TITLE
Input hashes + protein sequences

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,13 @@ jobs:
           # TODO nf-core: You can customise CI pipeline run tests as required
           # (eg. adding multiple test runs with different parameters)
           nextflow run ${GITHUB_WORKSPACE} -profile test_bam,docker
+      - name: Test input is protein
+        run: |
+          # TODO nf-core: You can customise CI pipeline run tests as required
+          # (eg. adding multiple test runs with different parameters)
+          nextflow run ${GITHUB_WORKSPACE} -profile test_input_is_protein,docker
+      - name: Test hash2kmer
+        run: |
+          # TODO nf-core: You can customise CI pipeline run tests as required
+          # (eg. adding multiple test runs with different parameters)
+          nextflow run ${GITHUB_WORKSPACE} -profile test_hash2kmer,docker

--- a/bin/hash2kmer.py
+++ b/bin/hash2kmer.py
@@ -15,7 +15,7 @@ import csv
 from sourmash.logging import notify, error
 from sourmash.cli.utils import add_construct_moltype_args
 from sourmash.sourmash_args import calculate_moltype
-
+from khtools.sequence_encodings import encode_peptide
 
 NOTIFY_EVERY_BP=1e7
 
@@ -27,6 +27,8 @@ def get_kmer_moltype(sequence, start, ksize, moltype, input_is_protein):
         kmer_rc = screed.rc(kmer)
         if kmer > kmer_rc:                # choose fwd or rc
             kmer = kmer_rc
+    elif input_is_protein:
+        kmer = encode_peptide(kmer, moltype)
     elif not input_is_protein:
         raise NotImplementedError("Currently cannot translate DNA to protein "
                                   "sequence")
@@ -171,8 +173,8 @@ def get_matching_hashes_in_file(filename, ksize, moltype, input_is_protein,
                 seqout_fp.write('>{}\n{}\n'.format(record.name,
                                                    record.sequence))
                 m += len(record.sequence)
-                if first:
-                    break
+            if first:
+                break
     return m, n
 
 if __name__ == '__main__':

--- a/bin/hash2kmer.py
+++ b/bin/hash2kmer.py
@@ -56,8 +56,10 @@ def get_kmers_for_hashvals(sequence, hashvals, ksize, moltype,
     ksize = revise_ksize(ksize, moltype, input_is_protein)
 
     for start in range(0, len(sequence) - ksize + 1):
-
         # Skip protein sequences with invalid input
+        # (workaround for khtools bug that wrote "Writing extract_coding
+        # summary to coding_summary.json" to standard output and thus to the
+        # protein fasta)
         if input_is_protein:
             if not all(x in AMINO_ACID_SINGLE_LETTERS for x in sequence):
                 continue

--- a/bin/hash2kmer.py
+++ b/bin/hash2kmer.py
@@ -77,6 +77,11 @@ def main():
         '--input-is-protein', action='store_true',
         help='Consume protein sequences - no translation needed.'
     )
+    p.add_argument(
+        '--first', action='store_true',
+        help='Return only the first instance of the found k-mer(s) and ' \
+             'sequence. Useful if you are searching for only one k-mer'
+    )
     add_construct_moltype_args(p)
     args = p.parse_args()
 
@@ -100,7 +105,7 @@ def main():
         kmerout_fp = open(args.output_kmers, 'wt')
         kmerout_w = csv.writer(kmerout_fp)
         kmerout_w.writerow(['kmer', 'hashval'])
-        
+
     # Ensure that protein ksizes are divisible by 3
     if (args.protein or args.dayhoff or args.hp) and not args.input_is_protein:
         if args.ksize % 3 != 0:
@@ -147,7 +152,7 @@ def main():
 
 def get_matching_hashes_in_file(filename, ksize, moltype, input_is_protein,
                                 hashes, found_kmers, m, n,
-                                n_seq, seqout_fp, watermark):
+                                n_seq, seqout_fp, watermark, first=False):
     for record in screed.open(filename):
         n += len(record.sequence)
         n_seq += 1
@@ -166,6 +171,8 @@ def get_matching_hashes_in_file(filename, ksize, moltype, input_is_protein,
                 seqout_fp.write('>{}\n{}\n'.format(record.name,
                                                    record.sequence))
                 m += len(record.sequence)
+                if first:
+                    break
     return m, n
 
 if __name__ == '__main__':

--- a/bin/hash2kmer.py
+++ b/bin/hash2kmer.py
@@ -174,7 +174,7 @@ def get_matching_hashes_in_file(filename, ksize, moltype, input_is_protein,
                                                    record.sequence))
                 m += len(record.sequence)
             if first:
-                break
+                return m, n
     return m, n
 
 if __name__ == '__main__':

--- a/bin/hash2kmer.py
+++ b/bin/hash2kmer.py
@@ -96,6 +96,11 @@ def main():
         error('must specify --ksize')
         return -1
 
+    if args.output_kmers:
+        kmerout_fp = open(args.output_kmers, 'wt')
+        kmerout_w = csv.writer(kmerout_fp)
+        kmerout_w.writerow(['kmer', 'hashval'])
+        
     # Ensure that protein ksizes are divisible by 3
     if (args.protein or args.dayhoff or args.hp) and not args.input_is_protein:
         if args.ksize % 3 != 0:
@@ -134,11 +139,6 @@ def main():
         notify('read {} bp, wrote {} bp in matching sequences', n, m)
 
     if kmerout_fp and found_kmers:
-        if args.output_kmers:
-            kmerout_fp = open(args.output_kmers, 'wt')
-            kmerout_w = csv.writer(kmerout_fp)
-            kmerout_w.writerow(['kmer', 'hashval'])
-
         for kmer, hashval in found_kmers.items():
             kmerout_w.writerow([kmer, str(hashval)])
         notify('read {} bp, found {} kmers matching hashvals', n,

--- a/bin/hash2kmer.py
+++ b/bin/hash2kmer.py
@@ -86,10 +86,6 @@ def main():
         seqout_fp = open(args.output_sequences, 'wt')
 
     kmerout_fp = None
-    if args.output_kmers:
-        kmerout_fp = open(args.output_kmers, 'wt')
-        kmerout_w = csv.writer(kmerout_fp)
-        kmerout_w.writerow(['kmer', 'hashval'])
 
     if not (seqout_fp or kmerout_fp):
         error("No output options given!")
@@ -137,7 +133,12 @@ def main():
     if seqout_fp:
         notify('read {} bp, wrote {} bp in matching sequences', n, m)
 
-    if kmerout_fp:
+    if kmerout_fp and found_kmers:
+        if args.output_kmers:
+            kmerout_fp = open(args.output_kmers, 'wt')
+            kmerout_w = csv.writer(kmerout_fp)
+            kmerout_w.writerow(['kmer', 'hashval'])
+
         for kmer, hashval in found_kmers.items():
             kmerout_w.writerow([kmer, str(hashval)])
         notify('read {} bp, found {} kmers matching hashvals', n,

--- a/bin/hash2kmer.py
+++ b/bin/hash2kmer.py
@@ -82,7 +82,7 @@ def main():
                    help='save matching sequences to this file.')
     p.add_argument('--output-kmers', type=str, default=None,
                    help='save matching kmers to this file.')
-    p.add_argument('-k', '--ksize', default=None, type=int)
+    p.add_argument('-k', '--ksize', type=int, required=True)
     p.add_argument(
         '--input-is-protein', action='store_true',
         help='Consume protein sequences - no translation needed.'
@@ -106,11 +106,6 @@ def main():
     if not (seqout_fp or kmerout_fp):
         error("No output options given!")
         return(-1)
-
-    # check arguments.
-    if not args.ksize:
-        error('must specify --ksize')
-        return -1
 
     if args.output_kmers:
         kmerout_fp = open(args.output_kmers, 'wt')

--- a/bin/hash2kmer.py
+++ b/bin/hash2kmer.py
@@ -82,7 +82,8 @@ def main():
     p.add_argument(
         '--first', action='store_true',
         help='Return only the first instance of the found k-mer(s) and ' \
-             'sequence. Useful if you are searching for only one k-mer'
+             'sequence from each provided sequence file. Useful if you are ' \
+             'searching for only one k-mer'
     )
     add_construct_moltype_args(p)
     args = p.parse_args()

--- a/bin/hash2kmer.py
+++ b/bin/hash2kmer.py
@@ -150,6 +150,8 @@ def main():
         m, n = get_matching_hashes_in_file(
             filename, args.ksize, moltype, args.input_is_protein, hashes,
             found_kmers, m, n, n_seq, seqout_fp, watermark, args.first)
+        if args.first and m > 0:
+            break
 
     if seqout_fp:
         notify('read {} bp, wrote {} bp in matching sequences', n, m)

--- a/bin/hash2kmer.py
+++ b/bin/hash2kmer.py
@@ -15,7 +15,7 @@ import csv
 from sourmash.logging import notify, error
 from sourmash.cli.utils import add_construct_moltype_args
 from sourmash.sourmash_args import calculate_moltype
-from khtools.sequence_encodings import encode_peptide
+from khtools.sequence_encodings import encode_peptide, AMINO_ACID_SINGLE_LETTERS
 
 NOTIFY_EVERY_BP=1e7
 
@@ -56,6 +56,12 @@ def get_kmers_for_hashvals(sequence, hashvals, ksize, moltype,
     ksize = revise_ksize(ksize, moltype, input_is_protein)
 
     for start in range(0, len(sequence) - ksize + 1):
+
+        # Skip protein sequences with invalid input
+        if input_is_protein:
+            if not all(x in AMINO_ACID_SINGLE_LETTERS for x in sequence):
+                continue
+
         kmer = get_kmer_moltype(sequence, start, ksize, moltype,
                                 input_is_protein)
 

--- a/bin/hash2kmer.py
+++ b/bin/hash2kmer.py
@@ -140,7 +140,7 @@ def main():
     for filename in args.seqfiles:
         m, n = get_matching_hashes_in_file(
             filename, args.ksize, moltype, args.input_is_protein, hashes,
-            found_kmers, m, n, n_seq, seqout_fp, watermark)
+            found_kmers, m, n, n_seq, seqout_fp, watermark, args.first)
 
     if seqout_fp:
         notify('read {} bp, wrote {} bp in matching sequences', n, m)

--- a/bin/hash2kmer.py
+++ b/bin/hash2kmer.py
@@ -1,0 +1,171 @@
+#! /usr/bin/env python3
+"""
+Given a list of hash values and a collection of sequences, output
+all of the k-mers that match a hashval.
+NOTE: for now, only implemented for DNA & for seed=42.
+"""
+import sys
+import argparse
+import sourmash
+from sourmash import MinHash
+from sourmash import sourmash_args
+from sourmash._minhash import hash_murmur
+import screed
+import csv
+from sourmash.logging import notify, error
+from sourmash.cli.utils import add_construct_moltype_args
+from sourmash.sourmash_args import calculate_moltype
+
+
+NOTIFY_EVERY_BP=1e7
+
+
+def get_kmer_moltype(sequence, start, ksize, moltype, input_is_protein):
+    kmer = sequence[start:start + ksize]
+    if moltype == "DNA":
+        # Get reverse complement
+        kmer_rc = screed.rc(kmer)
+        if kmer > kmer_rc:                # choose fwd or rc
+            kmer = kmer_rc
+    elif not input_is_protein:
+        raise NotImplementedError("Currently cannot translate DNA to protein "
+                                  "sequence")
+    return kmer
+
+
+def revise_ksize(ksize, moltype, input_is_protein):
+    """If input is protein, then divide the ksize by three"""
+    if moltype == "DNA":
+        return ksize
+    elif input_is_protein:
+        # Ksize includes codons
+        return int(ksize / 3)
+    else:
+        return ksize
+
+
+def get_kmers_for_hashvals(sequence, hashvals, ksize, moltype,
+                           input_is_protein):
+    "Return k-mers from 'sequence' that yield hashes in 'hashvals'."
+    # uppercase!
+    sequence = sequence.upper()
+
+    # Divide ksize by 3 if sequence is protein
+    ksize = revise_ksize(ksize, moltype, input_is_protein)
+
+    for start in range(0, len(sequence) - ksize + 1):
+        kmer = get_kmer_moltype(sequence, start, ksize, moltype,
+                                input_is_protein)
+
+        # NOTE: we do not avoid non-ACGT characters, because those k-mers,
+        # when hashed, shouldn't match anything that sourmash outputs.
+        hashval = hash_murmur(kmer)
+        if hashval in hashvals:
+            yield kmer, hashval
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('hashfile') 					# file that contains hashes
+    p.add_argument('seqfiles', nargs='+')		# sequence files from which to look for matches
+    p.add_argument('--output-sequences', type=str, default=None,
+                   help='save matching sequences to this file.')
+    p.add_argument('--output-kmers', type=str, default=None,
+                   help='save matching kmers to this file.')
+    p.add_argument('-k', '--ksize', default=None, type=int)
+    p.add_argument(
+        '--input-is-protein', action='store_true',
+        help='Consume protein sequences - no translation needed.'
+    )
+    add_construct_moltype_args(p)
+    args = p.parse_args()
+
+    # set up the outputs.
+    seqout_fp = None
+    if args.output_sequences:
+        seqout_fp = open(args.output_sequences, 'wt')
+
+    kmerout_fp = None
+    if args.output_kmers:
+        kmerout_fp = open(args.output_kmers, 'wt')
+        kmerout_w = csv.writer(kmerout_fp)
+        kmerout_w.writerow(['kmer', 'hashval'])
+
+    if not (seqout_fp or kmerout_fp):
+        error("No output options given!")
+        return(-1)
+
+    # check arguments.
+    if not args.ksize:
+        error('must specify --ksize')
+        return -1
+
+    # Ensure that protein ksizes are divisible by 3
+    if (args.protein or args.dayhoff or args.hp) and not args.input_is_protein:
+        if args.ksize % 3 != 0:
+            error('protein ksizes must be divisible by 3, sorry!')
+            error('bad ksizes: {}', ", ".join(args.ksize))
+            sys.exit(-1)
+
+    # load in all the hashes
+    hashes = set()
+    for line in open(args.hashfile, 'rt'):
+        hashval = int(line.strip())
+        hashes.add(hashval)
+
+    moltype = calculate_moltype(args)
+
+    if not hashes:
+        error("ERROR, no hashes loaded from {}!", args.hashfile)
+        return -1
+
+    notify('loaded {} distinct hashes from {}', len(hashes), args.hashfile)
+
+    # now, iterate over the input sequences and output those that overlap
+    # with hashes!
+    n_seq = 0
+    n = 0 # bp loaded
+    m = 0 # bp in found sequences
+    p = 0 # number of k-mers found
+    found_kmers = {}
+    watermark = NOTIFY_EVERY_BP
+    for filename in args.seqfiles:
+        m, n = get_matching_hashes_in_file(
+            filename, args.ksize, moltype, args.input_is_protein, hashes,
+            found_kmers, m, n, n_seq, seqout_fp, watermark)
+
+    if seqout_fp:
+        notify('read {} bp, wrote {} bp in matching sequences', n, m)
+
+    if kmerout_fp:
+        for kmer, hashval in found_kmers.items():
+            kmerout_w.writerow([kmer, str(hashval)])
+        notify('read {} bp, found {} kmers matching hashvals', n,
+               len(found_kmers))
+
+
+def get_matching_hashes_in_file(filename, ksize, moltype, input_is_protein,
+                                hashes, found_kmers, m, n,
+                                n_seq, seqout_fp, watermark):
+    for record in screed.open(filename):
+        n += len(record.sequence)
+        n_seq += 1
+        while n >= watermark:
+            sys.stderr.write(
+                '... {} {} {}\r'.format(n_seq, watermark, filename))
+            watermark += NOTIFY_EVERY_BP
+
+        # now do the hard work of finding the matching k-mers!
+        for kmer, hashval in get_kmers_for_hashvals(
+                record.sequence, hashes, ksize, moltype, input_is_protein):
+            found_kmers[kmer] = hashval
+
+            # write out sequence
+            if seqout_fp:
+                seqout_fp.write('>{}\n{}\n'.format(record.name,
+                                                   record.sequence))
+                m += len(record.sequence)
+    return m, n
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/conf/base.config
+++ b/conf/base.config
@@ -32,7 +32,7 @@ process {
     time = { check_max( 6.h * task.attempt, 'time' ) }
   }
   withLabel:process_medium {
-    cpus = { check_max( 6 * task.attempt, 'cpus' ) }
+    cpus = { check_max( 4 * task.attempt, 'cpus' ) }
     memory = { check_max( 42.GB * task.attempt, 'memory' ) }
     time = { check_max( 8.h * task.attempt, 'time' ) }
   }

--- a/conf/base.config
+++ b/conf/base.config
@@ -27,7 +27,7 @@ process {
   // TODO nf-core: Customise requirements for specific processes.
   // See https://www.nextflow.io/docs/latest/config.html#config-process-selectors
   withLabel:process_low {
-    cpus = { check_max( 2 * task.attempt, 'cpus' ) }
+    cpus = { check_max( 1 * task.attempt, 'cpus' ) }
     memory = { check_max( 14.GB * task.attempt, 'memory' ) }
     time = { check_max( 6.h * task.attempt, 'time' ) }
   }
@@ -47,5 +47,5 @@ process {
   withName:get_software_versions {
     cache = false
   }
-  
+
 }

--- a/conf/test_hash2kmer.config
+++ b/conf/test_hash2kmer.config
@@ -1,0 +1,27 @@
+/*
+ * -------------------------------------------------
+ *  Nextflow config file for running tests
+ * -------------------------------------------------
+ * Defines bundled input files and everything required
+ * to run a fast and simple test. Use as follows:
+ *   nextflow run nf-core/predictorthologs -profile test,<docker/singularity>
+ */
+
+params {
+  config_profile_name = 'Test profile'
+  config_profile_description = 'Minimal test dataset to check pipeline function'
+  // Limit resources so that this can run on Travis
+  max_cpus = 2
+  max_memory = 6.GB
+  max_time = 48.h
+  // Input data
+  hashes = 'https://github.com/czbiohub/test-datasets/raw/olgabot/predictorthologs-hash2kmer/testdata/liver_unaligned__hashes.txt'
+  csv_protein_fasta = 'https://github.com/czbiohub/test-datasets/raw/olgabot/predictorthologs-hash2kmer/testdata/liver_unaligned__samples.csv'
+  hash2kmer_molecule = 'dayhoff'
+  hash2kmer_ksize = 45
+
+  diamond_protein_fasta = 'https://github.com/czbiohub/test-datasets/raw/predictorthologs/reference/ncbi_refseq_vertebrate_mammalian_ptprc.fasta'
+  diamond_refseq_release = false
+  diamond_taxonmap_gz = "https://github.com/czbiohub/test-datasets/raw/predictorthologs/reference/prot.accession2taxid.vertebrate_mammalian_ptprc.with_header.txt.gz"
+
+}

--- a/conf/test_input_is_protein.config
+++ b/conf/test_input_is_protein.config
@@ -1,0 +1,35 @@
+/*
+ * -------------------------------------------------
+ *  Nextflow config file for running tests
+ * -------------------------------------------------
+ * Defines bundled input files and everything required
+ * to run a fast and simple test. Use as follows:
+ *   nextflow run nf-core/predictorthologs -profile test,<docker/singularity>
+ */
+
+params {
+  config_profile_name = 'Test profile'
+  config_profile_description = 'Minimal test dataset to check pipeline function'
+  // Limit resources so that this can run on Travis
+  max_cpus = 2
+  max_memory = 6.GB
+  max_time = 48.h
+  // Input data
+  protein_fasta_paths = [
+  ["10x_mouse_lung_ptprc",
+    ['https://github.com/czbiohub/test-datasets/raw/predictorthologs/testdata/10x_mouse_lung_ptprc__molecule-dayhoff__coding_reads_peptides.fasta']],
+  ["human_liver_ptprc",
+      ['https://github.com/czbiohub/test-datasets/raw/predictorthologs/testdata/human_liver_ptprc__molecule-dayhoff__coding_reads_peptides.fasta']],
+  ["orangutan_brain_ptprc",
+      ['https://github.com/czbiohub/test-datasets/raw/predictorthologs/testdata/orangutan_brain_ptprc__molecule-dayhoff__coding_reads_peptides.fasta']],
+  ["bonobo_liver_ptprc",
+      ['https://github.com/czbiohub/test-datasets/raw/predictorthologs/testdata/bonobo_liver_ptprc__molecule-dayhoff__coding_reads_peptides.fasta']]]
+
+  extract_coding_peptide_fasta = 'https://raw.githubusercontent.com/czbiohub/test-datasets/predictorthologs/reference/ncbi_refseq_vertebrate_mammalian_ptprc.fasta'
+  extract_coding_peptide_molecule = 'dayhoff'
+
+  diamond_protein_fasta = 'https://github.com/czbiohub/test-datasets/raw/predictorthologs/reference/ncbi_refseq_vertebrate_mammalian_ptprc.fasta'
+  diamond_refseq_release = false
+  diamond_taxonmap_gz = "https://github.com/czbiohub/test-datasets/raw/predictorthologs/reference/prot.accession2taxid.vertebrate_mammalian_ptprc.with_header.txt.gz"
+
+}

--- a/main.nf
+++ b/main.nf
@@ -609,8 +609,9 @@ if (!input_is_protein){
     file(sequences) into ch_coding_peptides_nonempty
 
     script:
-    kmers = "${peptide_fasta.baseName}__hash-${hash}__kmer.txt"
-    sequences = "${peptide_fasta.baseName}__hash-${hash}__sequences.fasta"
+    hash_no_newline = hash.replaceAll("\\s", "")
+    kmers = "${peptide_fasta.baseName}__hash-${hash_no_newline}__kmer.txt"
+    sequences = "${peptide_fasta.baseName}__hash-${hash_no_newline}__sequences.fasta"
     """
     echo ${hash} >> hash.txt
     hash2kmer.py \\

--- a/main.nf
+++ b/main.nf
@@ -584,7 +584,7 @@ ch_coding_peptides
     sequences = "${peptide_fasta.baseName}__hash-${hash}__sequences.fasta"
     """
     echo ${hash} >> hash.txt
-    /home/olga/miniconda3/envs/tabula-microcebus-v2/bin/python hash2kmer.py \\
+    hash2kmer.py \\
         --ksize ${hash2kmer_ksize} \\
         --no-dna \\
         --input-is-protein \\

--- a/main.nf
+++ b/main.nf
@@ -795,7 +795,7 @@ process diamond_blastp {
       --threads ${task.cpus} \\
       --max-target-seqs 3 \\
       --db ${diamond_db} \\
-      --evalue 0.00000000001  \\
+      --evalue 0.00001  \\
       --query ${coding_peptides} \\
       > ${sample_bloom_id}__diamond__${diamond_db.baseName}.tsv
   """

--- a/main.nf
+++ b/main.nf
@@ -128,14 +128,12 @@ if (params.bam && params.bed && params.bai && !(params.reads || params.readPaths
         .set { ch_protein_fastas }
   } else if (params.csv_protein_fasta) {
     // Provided a csv file mapping sample_id to protein fasta path
-    if (params.csv_protein_fasta){
-      csv_singles_ch = Channel
-       .fromPath(params.csv_singles)
-       .splitCsv(header:true)
-       .map{ row -> tuple(row[0], tuple(file(row[1])))}
-       .ifEmpty { exit 1, "params.csv_singles (${params.csv_singles}) was empty - no input files supplied" }
-       .set { ch_protein_fastas }
-    }
+    csv_singles_ch = Channel
+     .fromPath(params.csv_singles)
+     .splitCsv(header:true)
+     .map{ row -> tuple(row[0], tuple(file(row[1])))}
+     .ifEmpty { exit 1, "params.csv_singles (${params.csv_singles}) was empty - no input files supplied" }
+     .set { ch_protein_fastas }
   }
   if (params.hashes){
     Channel.fromPath(params.hashes)

--- a/main.nf
+++ b/main.nf
@@ -161,7 +161,7 @@ if (params.bam && params.bed && params.bai && !(params.reads || params.readPaths
         .ifEmpty { exit 1, "params.hashes was empty - no input files supplied" }
         .splitText()
         .map{ row -> row.replaceAll("\\s+", "")}
-        .combine{ ch_protein_fastas }
+        .combine( ch_protein_fastas )
         .set { ch_hashes_fastas }
 
   } else {

--- a/main.nf
+++ b/main.nf
@@ -487,11 +487,6 @@ process khtools_peptide_bloom_filter {
   """
 }
 
-// From Paolo - how to do extract_coding on ALL combinations of bloom filters
- ch_khtools_bloom_filters
-  .groupTuple(by: [0, 3])
-    .combine(ch_reads_trimmed_nonempty)
-  .set{ ch_khtools_bloom_filters_grouptuple }
 
 ///////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
@@ -504,6 +499,13 @@ process khtools_peptide_bloom_filter {
  * STEP 3 - khtools extrct-coding
  */
 if (!input_is_protein){
+
+  // From Paolo - how to do extract_coding on ALL combinations of bloom filters
+   ch_khtools_bloom_filters
+    .groupTuple(by: [0, 3])
+      .combine(ch_reads_trimmed_nonempty)
+    .set{ ch_khtools_bloom_filters_grouptuple }
+
   process extract_coding {
     tag "${sample_id}"
     label "process_long"

--- a/main.nf
+++ b/main.nf
@@ -230,6 +230,11 @@ peptide_molecule = params.extract_coding_peptide_molecule
 jaccard_threshold = params.extract_coding_jaccard_threshold
 diamond_refseq_release = params.diamond_refseq_release
 
+//////////////////////////////////////////////////////////////////
+/* -                 Parse hash2kmer parameters              -- */
+//////////////////////////////////////////////////////////////////
+hash2kmer_ksize = params.hash2kmer_ksize
+
 ///////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
 /* --                                                                     -- */
@@ -594,7 +599,6 @@ if (!input_is_protein){
     val hash from ch_hashes
     val peptide_fasta from ch_protein_fastas
     val refseq_release from diamond_refseq_release
-    val hash2kmer_ksize from ch_hash2kmer_ksize
 
     output:
     file("${refseq_release}.fa.gz") into ch_diamond_protein_fasta

--- a/main.nf
+++ b/main.nf
@@ -632,7 +632,7 @@ if (!input_is_protein){
 ///////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
 /*
- * STEP 4 - rsync to download refeseq
+ * STEP 5 - rsync to download refeseq
  */
  if (!(params.diamond_database || params.diamond_protein_fasta) && params.diamond_refseq_release){
   // No protein fasta provided for searching for orthologs, need to
@@ -672,7 +672,7 @@ if (!input_is_protein){
 ///////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
 /*
- * STEP 5 - unzip taxonomy information files for input to DIAMOND
+ * STEP 6 - unzip taxonomy information files for input to DIAMOND
  */
 if (!params.diamond_database){
   process diamond_prepare_taxa {
@@ -704,7 +704,7 @@ if (!params.diamond_database){
 ///////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
 /*
- * STEP 6 - make peptide search database for DIAMOND
+ * STEP 7 - make peptide search database for DIAMOND
  */
 if (!params.diamond_database && (params.diamond_protein_fasta || params.diamond_refseq_release)){
   process diamond_makedb {
@@ -749,7 +749,7 @@ if (!params.diamond_database && (params.diamond_protein_fasta || params.diamond_
 ///////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
 /*
- * STEP 7 - Search DIAMOND database for closest match to
+ * STEP 8 - Search DIAMOND database for closest match to
  */
 process diamond_blastp {
   tag "${sample_bloom_id}"
@@ -794,7 +794,7 @@ process diamond_blastp {
 ///////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
 /*
- * STEP 8 - MultiQC
+ * STEP 9 - MultiQC
  */
 process multiqc {
     publishDir "${params.outdir}/MultiQC", mode: 'copy'
@@ -824,7 +824,7 @@ process multiqc {
 }
 
 /*
- * STEP 3 - Output Description HTML
+ * STEP 10 - Output Description HTML
  */
 process output_documentation {
     publishDir "${params.outdir}/pipeline_info", mode: 'copy'

--- a/main.nf
+++ b/main.nf
@@ -150,9 +150,7 @@ if (params.bam && params.bed && params.bai && !(params.reads || params.readPaths
     Channel
       .fromPath(params.csv_protein_fasta)
       .splitCsv(header:true)
-      .view()
       .map{ row -> tuple(row.sample_id, tuple(file(row.peptide_fasta)))}
-      .view()
       .ifEmpty { exit 1, "params.csv_protein_fasta (${params.csv_protein_fasta}) was empty - no input files supplied" }
       .set { ch_protein_fastas }
   }

--- a/main.nf
+++ b/main.nf
@@ -598,7 +598,7 @@ if (!input_is_protein){
   // No protein fasta provided for searching for orthologs, need to
   // download refseq
   process hash2kmer {
-    tag "${sample_id}__${hash}"
+    tag "${sample_id}"
     label "process_low"
 
     publishDir "${params.outdir}/hash2kmer/", mode: 'copy'
@@ -608,11 +608,12 @@ if (!input_is_protein){
 
     output:
     file(kmers)
-    file(sequences) into ch_coding_peptides_nonempty
+    set val(sample_id), file(sequences) into ch_coding_peptides_nonempty
 
     script:
-    kmers = "${peptide_fasta.baseName}__hash-${hash}__kmer.txt"
-    sequences = "${peptide_fasta.baseName}__hash-${hash}__sequences.fasta"
+    sample_id = "${peptide_fasta.baseName}__hash-${hash}"
+    kmers = "${sample_id}__kmer.txt"
+    sequences = "${sample_id}__sequences.fasta"
     """
     echo ${hash} >> hash.txt
     hash2kmer.py \\

--- a/main.nf
+++ b/main.nf
@@ -352,7 +352,7 @@ process get_software_versions {
 if (params.bam && params.bed && params.bai) {
     process samtools_view_fastq {
   	tag "$interval_name"
-  	label "process_medium"
+  	label "process_low"
   	publishDir "${params.outdir}/intersect_fastqs", mode: 'copy'
 
   	input:

--- a/main.nf
+++ b/main.nf
@@ -860,7 +860,8 @@ process multiqc {
     custom_config_file = params.multiqc_config ? "--config $mqc_custom_config" : ''
     // TODO nf-core: Specify which MultiQC modules to use with -m for a faster run time
     """
-    multiqc -f $rtitle $rfilename $custom_config_file -m fastqc -m fastp .
+    multiqc -f $rtitle $rfilename $custom_config_file -m fastqc -m fastp . 
+    touch multiqc_report.html multiqc_plots _data
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -591,14 +591,14 @@ if (!input_is_protein){
   // No protein fasta provided for searching for orthologs, need to
   // download refseq
   process hash2kmer {
-    tag "${refseq_release}"
+    tag "${sample_id}__${hash}"
     label "process_low"
 
     publishDir "${params.outdir}/hash2kmer/", mode: 'copy'
 
     input:
     val hash from ch_hashes
-    val peptide_fasta from ch_protein_fastas
+    val(sample_id), file(peptide_fasta) from ch_protein_fastas
 
     output:
     file(kmers)

--- a/main.nf
+++ b/main.nf
@@ -161,7 +161,9 @@ if (params.bam && params.bed && params.bai && !(params.reads || params.readPaths
         .ifEmpty { exit 1, "params.hashes was empty - no input files supplied" }
         .splitText()
         .map{ row -> row.replaceAll("\\s+", "")}
-        .set { ch_hashes }
+        .combine{ ch_protein_fastas }
+        .set { ch_hashes_fastas }
+
   } else {
     // No hashes - just do a diamond blastp search for each peptide fasta
     ch_coding_peptides_nonempty = ch_protein_fastas
@@ -602,8 +604,7 @@ if (!input_is_protein){
     publishDir "${params.outdir}/hash2kmer/", mode: 'copy'
 
     input:
-    val hash from ch_hashes
-    set val(sample_id), file(peptide_fasta) from ch_protein_fastas
+    tuple val(hash), val(sample_id), file(peptide_fasta) from ch_hashes_fastas
 
     output:
     file(kmers)

--- a/main.nf
+++ b/main.nf
@@ -21,16 +21,35 @@ def helpMessage() {
     nextflow run nf-core/predictorthologs --reads '*_R{1,2}.fastq.gz' -profile docker
 
     Mandatory arguments:
-      --reads [file]                Path to input data (must be surrounded with quotes)
       -profile [str]                Configuration profile to use. Can use multiple (comma separated)
                                     Available: conda, docker, singularity, test, awsbatch, <institute> and more
+    Input Options:
+      Sequencing reads (FASTQ format):
+        --reads [file]                Path to input data (must be surrounded with quotes)
+      Protein input:
+        --protein_fastas
+        --csv_protein_fasta
+        --hashes
+      Bam + bed file for intersection:
+        --bam
+        --bai
+        --bed
 
     Options:
-      --genome [str]                  Name of iGenomes reference
       --single_end [bool]             Specifies that the input is single-end reads
 
-    References                        If not specified in the configuration file or you wish to overwrite any of the references
-      --fasta [file]                  Path to fasta reference
+    BLAST-like protein search options                        If not specified in the configuration file or you wish to overwrite any of the references
+      --diamond_refseq_release        Valid terms from ftp://ftp.ncbi.nlm.nih.gov/refseq/release/,
+                                      e.g. "complete", "archea", "plasmid", "protozoa", "viral".
+                                      Default is "vertebrate_mammalian"
+      --diamond_protein_fasta         Use all of manually curated, verified UniProt/SwissProt as the reference
+                                      proteome for searching for orthologs
+      --diamond_database              Pre-created database with DIAMOND
+      --diamond_taxonmap_gz           Mapping of protein IDs to taxa
+                                      Default is: "ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/accession2taxid/prot.accession2taxid.gz"
+      --diamond_taxdmp_zip            Taxonomy dump file from NCBI
+                                      Default is: "ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdmp.zip"
+
 
     Other options:
       --outdir [file]                 The output directory where the results will be saved

--- a/main.nf
+++ b/main.nf
@@ -598,7 +598,7 @@ if (!input_is_protein){
 
     input:
     val hash from ch_hashes
-    val(sample_id), file(peptide_fasta) from ch_protein_fastas
+    set val(sample_id), file(peptide_fasta) from ch_protein_fastas
 
     output:
     file(kmers)

--- a/main.nf
+++ b/main.nf
@@ -476,6 +476,8 @@ if (!params.skip_trimming && !input_is_protein){
       .set { ch_reads_trimmed_nonempty }
 } else if (!input_is_protein) {
   ch_reads_trimmed_nonempty = ch_read_files_trimming
+} else {
+  ch_fastp_results = Channel.empty()
 }
 
 

--- a/main.nf
+++ b/main.nf
@@ -860,7 +860,7 @@ process multiqc {
     custom_config_file = params.multiqc_config ? "--config $mqc_custom_config" : ''
     // TODO nf-core: Specify which MultiQC modules to use with -m for a faster run time
     """
-    multiqc -f $rtitle $rfilename $custom_config_file -m fastqc -m fastp . 
+    multiqc -f $rtitle $rfilename $custom_config_file -m fastqc -m fastp .
     touch multiqc_report.html multiqc_plots _data
     """
 }

--- a/main.nf
+++ b/main.nf
@@ -151,7 +151,7 @@ if (params.bam && params.bed && params.bai && !(params.reads || params.readPaths
       .fromPath(params.csv_protein_fasta)
       .splitCsv(header:true)
       .view()
-      .map{ row -> tuple(row[0], tuple(file(row[1])))}
+      .map{ row -> tuple(row.sample_id, tuple(file(row.peptide_fasta)))}
       .view()
       .ifEmpty { exit 1, "params.csv_protein_fasta (${params.csv_protein_fasta}) was empty - no input files supplied" }
       .set { ch_protein_fastas }

--- a/main.nf
+++ b/main.nf
@@ -606,7 +606,7 @@ if (!input_is_protein){
     tag "${sample_id}"
     label "process_low"
 
-    publishDir "${params.outdir}/hash2kmer/", mode: 'copy'
+    publishDir "${params.outdir}/hash2kmer/${hash_id}", mode: 'copy'
 
     input:
     tuple val(hash), val(sample_id), file(peptide_fasta) from ch_hashes_fastas
@@ -616,7 +616,8 @@ if (!input_is_protein){
     set val(sample_id), file(sequences) into ch_coding_peptides
 
     script:
-    sample_id = "hash-${hash}__${peptide_fasta.baseName}"
+    hash_id = "hash-${hash}"
+    sample_id = "${hash_id}__${peptide_fasta.baseName}"
     kmers = "${sample_id}__kmer.txt"
     sequences = "${sample_id}__sequences.fasta"
     """

--- a/main.nf
+++ b/main.nf
@@ -223,7 +223,6 @@ if (params.diamond_database){
        .set{ ch_diamond_db }
 }
 
-
 //////////////////////////////////////////////////////////////////
 /* -     Parse extract_coding and diamond parameters         -- */
 //////////////////////////////////////////////////////////////////
@@ -259,8 +258,8 @@ if (params.protein_fastas) summary['Input protein fastas']                  = pa
 if (params.csv_protein_fasta) summary['CSV of protein fastas']              = params.csv_protein_fasta
 // How the DIAMOND search database is created
 if (params.diamond_protein_fasta) summary['DIAMOND Proteome fasta']         = params.diamond_protein_fasta
-if (params.diamond_refseq_release) summary['DIAMOND Refseq release']        = params.diamond_refseq_release
-if (params.diamond_protein_fasta) summary['DIAMOND pre-build database']     = params.diamond_database
+if (!params.diamond_database && params.diamond_refseq_release) summary['DIAMOND Refseq release']        = params.diamond_refseq_release
+if (params.diamond_database) summary['DIAMOND pre-build database']     = params.diamond_database
 summary['Map sequences to taxon']     = params.diamond_taxonmap_gz
 summary['Taxonomy database dump']     = params.diamond_taxdmp_zip
 summary['Data Type']        = params.single_end ? 'Single-End' : 'Paired-End'

--- a/main.nf
+++ b/main.nf
@@ -587,7 +587,7 @@ if (!input_is_protein){
 /*
  * STEP 4 - convert hashes to k-mers
  */
- if (!(params.diamond_database || params.diamond_protein_fasta) && params.diamond_refseq_release){
+ if (input_is_protein && params.hashes){
   // No protein fasta provided for searching for orthologs, need to
   // download refseq
   process hash2kmer {

--- a/main.nf
+++ b/main.nf
@@ -197,9 +197,9 @@ if (params.bam && params.bed && params.bai && !(params.reads || params.readPaths
 /* --        Parse reference proteomes         -- */
 ////////////////////////////////////////////////////
 if (params.extract_coding_peptide_fasta) {
-Channel.fromPath(params.extract_coding_peptide_fasta, checkIfExists: true)
-     .ifEmpty { exit 1, "Peptide fasta file not found: ${params.extract_coding_peptide_fasta}" }
-     .set{ ch_extract_coding_peptide_fasta }
+  Channel.fromPath(params.extract_coding_peptide_fasta, checkIfExists: true)
+       .ifEmpty { exit 1, "Peptide fasta file not found: ${params.extract_coding_peptide_fasta}" }
+       .set{ ch_extract_coding_peptide_fasta }
 }
 
 if (params.diamond_protein_fasta) {
@@ -258,7 +258,7 @@ if (params.protein_fastas) summary['Input protein fastas']                  = pa
 if (params.csv_protein_fasta) summary['CSV of protein fastas']              = params.csv_protein_fasta
 // How the DIAMOND search database is created
 if (params.diamond_protein_fasta) summary['DIAMOND Proteome fasta']         = params.diamond_protein_fasta
-if (!params.diamond_database && params.diamond_refseq_release) summary['DIAMOND Refseq release']        = params.diamond_refseq_release
+if (!(params.diamond_database || params.diamond_protein_fasta) && params.diamond_refseq_release) summary['DIAMOND Refseq release']        = params.diamond_refseq_release
 if (params.diamond_database) summary['DIAMOND pre-build database']     = params.diamond_database
 summary['Map sequences to taxon']     = params.diamond_taxonmap_gz
 summary['Taxonomy database dump']     = params.diamond_taxdmp_zip

--- a/main.nf
+++ b/main.nf
@@ -160,6 +160,7 @@ if (params.bam && params.bed && params.bai && !(params.reads || params.readPaths
     Channel.fromPath(params.hashes)
         .ifEmpty { exit 1, "params.hashes was empty - no input files supplied" }
         .splitText()
+        .map{ row -> row.replaceAll("\\s+", "")}
         .set { ch_hashes }
   } else {
     // No hashes - just do a diamond blastp search for each peptide fasta
@@ -609,9 +610,8 @@ if (!input_is_protein){
     file(sequences) into ch_coding_peptides_nonempty
 
     script:
-    hash_no_newline = hash.replaceAll("\\s", "")
-    kmers = "${peptide_fasta.baseName}__hash-${hash_no_newline}__kmer.txt"
-    sequences = "${peptide_fasta.baseName}__hash-${hash_no_newline}__sequences.fasta"
+    kmers = "${peptide_fasta.baseName}__hash-${hash}__kmer.txt"
+    sequences = "${peptide_fasta.baseName}__hash-${hash}__sequences.fasta"
     """
     echo ${hash} >> hash.txt
     hash2kmer.py \\

--- a/main.nf
+++ b/main.nf
@@ -128,12 +128,12 @@ if (params.bam && params.bed && params.bai && !(params.reads || params.readPaths
         .set { ch_protein_fastas }
   } else if (params.csv_protein_fasta) {
     // Provided a csv file mapping sample_id to protein fasta path
-    csv_singles_ch = Channel
-     .fromPath(params.csv_singles)
-     .splitCsv(header:true)
-     .map{ row -> tuple(row[0], tuple(file(row[1])))}
-     .ifEmpty { exit 1, "params.csv_singles (${params.csv_singles}) was empty - no input files supplied" }
-     .set { ch_protein_fastas }
+    Channel
+      .fromPath(params.csv_protein_fasta)
+      .splitCsv(header:true)
+      .map{ row -> tuple(row[0], tuple(file(row[1])))}
+      .ifEmpty { exit 1, "params.csv_singles (${params.csv_singles}) was empty - no input files supplied" }
+      .set { ch_protein_fastas }
   }
   if (params.hashes){
     Channel.fromPath(params.hashes)

--- a/main.nf
+++ b/main.nf
@@ -403,6 +403,8 @@ if (!input_is_protein) {
       fastqc --quiet --threads $task.cpus $reads
       """
   }
+} else {
+  ch_fastqc_results = Channel.empty()
 }
 
 

--- a/main.nf
+++ b/main.nf
@@ -150,6 +150,7 @@ if (params.bam && params.bed && params.bai && !(params.reads || params.readPaths
     Channel
       .fromPath(params.csv_protein_fasta)
       .splitCsv(header:true)
+      .view()
       .map{ row -> tuple(row[0], tuple(file(row[1])))}
       .view()
       .ifEmpty { exit 1, "params.csv_protein_fasta (${params.csv_protein_fasta}) was empty - no input files supplied" }

--- a/main.nf
+++ b/main.nf
@@ -132,7 +132,7 @@ if (params.bam && params.bed && params.bai && !(params.reads || params.readPaths
       .fromPath(params.csv_protein_fasta)
       .splitCsv(header:true)
       .map{ row -> tuple(row[0], tuple(file(row[1])))}
-      .ifEmpty { exit 1, "params.csv_protein_fasta (${params.csv_singles}) was empty - no input files supplied" }
+      .ifEmpty { exit 1, "params.csv_protein_fasta (${params.csv_protein_fasta}) was empty - no input files supplied" }
       .set { ch_protein_fastas }
   }
   if (params.hashes){

--- a/main.nf
+++ b/main.nf
@@ -575,12 +575,6 @@ if (!input_is_protein){
     .filter{ it[1].size() > 0 }
     .dump(tag: "ch_coding_nucleotides_nonempty")
     .set{ ch_coding_nucleotides_nonempty }
-
-  ch_coding_peptides
-    .dump(tag: 'ch_coding_peptides')
-    .filter{ it[1].size() > 0 }
-    .dump(tag: "ch_coding_peptides_nonempty")
-    .set {ch_coding_peptides_nonempty}
 }
 
 
@@ -608,7 +602,7 @@ if (!input_is_protein){
 
     output:
     file(kmers)
-    set val(sample_id), file(sequences) into ch_coding_peptides_nonempty
+    set val(sample_id), file(sequences) into ch_coding_peptides
 
     script:
     sample_id = "${peptide_fasta.baseName}__hash-${hash}"
@@ -628,6 +622,12 @@ if (!input_is_protein){
     """
   }
 }
+
+ch_coding_peptides
+  .dump(tag: 'ch_coding_peptides')
+  .filter{ it[1].size() > 0 }
+  .dump(tag: "ch_coding_peptides_nonempty")
+  .set {ch_coding_peptides_nonempty}
 
 ///////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////

--- a/main.nf
+++ b/main.nf
@@ -616,7 +616,7 @@ if (!input_is_protein){
     set val(sample_id), file(sequences) into ch_coding_peptides
 
     script:
-    sample_id = "${peptide_fasta.baseName}__hash-${hash}"
+    sample_id = "hash-${hash}__${peptide_fasta.baseName}"
     kmers = "${sample_id}__kmer.txt"
     sequences = "${sample_id}__sequences.fasta"
     """

--- a/main.nf
+++ b/main.nf
@@ -132,6 +132,7 @@ if (params.bam && params.bed && params.bai && !(params.reads || params.readPaths
       .fromPath(params.csv_protein_fasta)
       .splitCsv(header:true)
       .map{ row -> tuple(row[0], tuple(file(row[1])))}
+      .view()
       .ifEmpty { exit 1, "params.csv_protein_fasta (${params.csv_protein_fasta}) was empty - no input files supplied" }
       .set { ch_protein_fastas }
   }

--- a/main.nf
+++ b/main.nf
@@ -631,7 +631,7 @@ if (!input_is_protein){
 
     output:
     file(kmers)
-    set val(sample_id), file(sequences) into ch_coding_peptides
+    set val(hash_id), file(sequences) into ch_coding_peptides
 
     script:
     hash_id = "hash-${hash}"

--- a/main.nf
+++ b/main.nf
@@ -758,7 +758,7 @@ if (!params.diamond_database && (params.diamond_protein_fasta || params.diamond_
  */
 process diamond_blastp {
   tag "${sample_bloom_id}"
-  label "process_high"
+  label "processs_medium"
 
   publishDir "${params.outdir}/diamond/blastp/", mode: 'copy'
 

--- a/main.nf
+++ b/main.nf
@@ -248,9 +248,21 @@ log.info nfcoreHeader()
 def summary = [:]
 if (workflow.revision) summary['Pipeline Release'] = workflow.revision
 summary['Run Name']         = custom_runName ?: workflow.runName
-// TODO nf-core: Report custom parameters here
-summary['Reads']            = params.reads
-summary['Fasta Ref']        = params.fasta
+// Input is sequencing reads --> need to convert to protein
+if (params.bam) summary['bam']                                              = params.bam
+if (params.bed) summary['bed']                                              = params.bed
+if (params.reads) summary['Reads']                                          = params.reads
+if (!input_is_protein) summary['kmerslay extract-coding Ref']               = params.extract_coding_peptide_fasta
+// Input is protein -- have protein sequences and hashes
+if (params.hashes) summary['Hashes']                                        = params.hashes
+if (params.protein_fastas) summary['Input protein fastas']                  = params.protein_fastas
+if (params.csv_protein_fasta) summary['CSV of protein fastas']              = params.csv_protein_fasta
+// How the DIAMOND search database is created
+if (params.diamond_protein_fasta) summary['DIAMOND Proteome fasta']         = params.diamond_protein_fasta
+if (params.diamond_refseq_release) summary['DIAMOND Refseq release']        = params.diamond_refseq_release
+if (params.diamond_protein_fasta) summary['DIAMOND pre-build database']     = params.diamond_database
+summary['Map sequences to taxon']     = params.diamond_taxonmap_gz
+summary['Taxonomy database dump']     = params.diamond_taxdmp_zip
 summary['Data Type']        = params.single_end ? 'Single-End' : 'Paired-End'
 summary['Max Resources']    = "$params.max_memory memory, $params.max_cpus cpus, $params.max_time time per job"
 if (workflow.containerEngine) summary['Container'] = "$workflow.containerEngine - $workflow.container"

--- a/main.nf
+++ b/main.nf
@@ -253,6 +253,7 @@ diamond_refseq_release = params.diamond_refseq_release
 /* -                 Parse hash2kmer parameters              -- */
 //////////////////////////////////////////////////////////////////
 hash2kmer_ksize = params.hash2kmer_ksize
+hash2kmer_molecule = params.hash2kmer_molecule
 
 ///////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
@@ -272,6 +273,8 @@ if (params.reads) summary['Reads']                                          = pa
 if (!input_is_protein) summary['kmerslay extract-coding Ref']               = params.extract_coding_peptide_fasta
 // Input is protein -- have protein sequences and hashes
 if (params.hashes) summary['Hashes']                                        = params.hashes
+if (params.hashes) summary['hash2kmer ksize']                               = params.hash2kmer_ksize
+if (params.hashes) summary['hash2kmer molecule']                            = params.hash2kmer_molecule
 if (params.protein_fastas) summary['Input protein fastas']                  = params.protein_fastas
 if (params.csv_protein_fasta) summary['CSV of protein fastas']              = params.csv_protein_fasta
 // How the DIAMOND search database is created
@@ -645,7 +648,7 @@ if (!input_is_protein){
         --input-is-protein \\
         --output-sequences ${sequences} \\
         --output-kmers ${kmers} \\
-        --protein \\
+        --${hash2kmer_molecule} \\
         --first \\
         hash.txt \\
         ${peptide_fastas}

--- a/main.nf
+++ b/main.nf
@@ -770,7 +770,7 @@ if (!params.diamond_database && (params.diamond_protein_fasta || params.diamond_
  */
 process diamond_blastp {
   tag "${sample_bloom_id}"
-  label "processs_medium"
+  label "process_medium"
 
   publishDir "${params.outdir}/diamond/blastp/", mode: 'copy'
 

--- a/main.nf
+++ b/main.nf
@@ -599,10 +599,8 @@ if (!input_is_protein){
     input:
     val hash from ch_hashes
     val peptide_fasta from ch_protein_fastas
-    val refseq_release from diamond_refseq_release
 
     output:
-    file("${refseq_release}.fa.gz") into ch_diamond_protein_fasta
     file(kmers)
     file(sequences) into ch_coding_peptides_nonempty
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -22,6 +22,7 @@ params {
 
   skip_trimming = false
 
+  csv_protein_fasta = false
   protein_fastas = false
   hashes = false
   hash2kmer_ksize = 21

--- a/nextflow.config
+++ b/nextflow.config
@@ -16,6 +16,8 @@ params {
   single_end = false
   outdir = './results'
 
+  skip_trimming = false
+
   protein_fastas = false
   hashes = false
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -99,9 +99,10 @@ profiles {
     singularity.autoMounts = true
   }
   test { includeConfig 'conf/test.config' }
+  test_bam { includeConfig 'conf/test_bam.config' }
   test_download_refseq { includeConfig 'conf/test_download_refseq.config' }
   test_existing_database { includeConfig 'conf/test_existing_database.config' }
-  test_bam { includeConfig 'conf/test_bam.config' }
+  test_hash2kmer { includeConfig 'conf/test_hash2kmer.config' }
   test_input_is_protein { includeConfig 'conf/test_input_is_protein.config' }
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,9 +12,12 @@ params {
   // TODO nf-core: Specify your pipeline's command line flags
   genome = false
   reads = false
-  readPaths = false  
+  readPaths = false
   single_end = false
   outdir = './results'
+
+  protein_fastas = false
+  hashes = false
 
   extract_coding_peptide_molecule = "protein"
   // UNIPROT human proteome is default reference. Human has Taxon ID 9606

--- a/nextflow.config
+++ b/nextflow.config
@@ -26,6 +26,7 @@ params {
   protein_fastas = false
   hashes = false
   hash2kmer_ksize = 21
+  hash2kmer_molecule = 'protein'
 
   extract_coding_peptide_molecule = "protein"
   // UNIPROT human proteome is default reference. Human has Taxon ID 9606

--- a/nextflow.config
+++ b/nextflow.config
@@ -100,6 +100,7 @@ profiles {
   test_download_refseq { includeConfig 'conf/test_download_refseq.config' }
   test_existing_database { includeConfig 'conf/test_existing_database.config' }
   test_bam { includeConfig 'conf/test_bam.config' }
+  test_input_is_protein { includeConfig 'conf/test_input_is_protein.config' }
 }
 
 // Load igenomes.config if required

--- a/nextflow.config
+++ b/nextflow.config
@@ -24,10 +24,13 @@ params {
 
   protein_fastas = false
   hashes = false
+  hash2kmer_ksize = 21
 
   extract_coding_peptide_molecule = "protein"
   // UNIPROT human proteome is default reference. Human has Taxon ID 9606
   extract_coding_peptide_fasta = "ftp://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/reference_proteomes/Eukaryota/UP000005640_9606.fasta.gz"
+  extract_coding_jaccard_threshold = 0.8
+  extract_coding_peptide_ksize = 7
 
   // Use all of manually curated, verified UniProt/SwissProt as the reference proteome for searching for orthologs
   diamond_protein_fasta = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -16,6 +16,10 @@ params {
   single_end = false
   outdir = './results'
 
+  bam = false
+  bed = false
+  bai = false
+
   skip_trimming = false
 
   protein_fastas = false


### PR DESCRIPTION
Allow for hashes + protein sequences, extract protein-coding sequences containing the hashes, then predict their functions using `DIAMOND blastp`

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the [nf-core/predictorthologs branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/predictorthologs)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Documentation in `docs` is updated
- [ ] `CHANGELOG.md` is updated
- [ ] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/predictorthologs/tree/master/.github/CONTRIBUTING.md)