### PR TITLE
Add ripgrep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,5 +22,6 @@ Initial release of nf-core/predictorthologs, created with the [nf-core](http://n
 - Added pandas=1.0.3, scikit-learn=0.22.1, and sourmash=3.2.2 to dependencies
 - Added subread=1.6.4 (featurecounts) and bioawk=1.0
 - Updated MultiQC to version 1.8 to avoid annoying YAML errors
+- Add ripgrep=12.0.1 ([faster than all other `grep`s](https://blog.burntsushi.net/ripgrep/)) to dependencies
 
 ### `Deprecated`

--- a/environment.yml
+++ b/environment.yml
@@ -33,5 +33,6 @@ dependencies:
   - conda-forge::rsync=3.1.3
   - subread=1.6.4
   - bioawk=1.0
+  - conda-forge::ripgrep=12.0.1
   - pip:
     - git+https://github.com/czbiohub/kh-tools.git@master#egg=khtools


### PR DESCRIPTION
Ripgrep, which is [faster](https://blog.burntsushi.net/ripgrep/) than all other `grep`-like tools will be used to search for fixed strings of read ids in bam files for https://github.com/czbiohub/nf-predictorthologs/pull/36

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] Make sure your code lints (`nf-core lint .`).
- [x] `CHANGELOG.md` is updated
