### PR TITLE
Bump sourmash version to 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,11 @@ Initial release of nf-core/predictorthologs, created with the [nf-core](http://n
 - Added rsync to download NCBI RefSeq releases
 - Actually installed `rsync` via apt in `Dockerfile`, not just `unzip` ([#16](https://github.com/czbiohub/nf-predictorthologs/pull/16))
 - Added bedtools=2.29.2 to dependencies
-- Added sourmash Rust (required for compiling sourmash from GitHub) ([#24](https://github.com/czbiohub/nf-predictorthologs/pull/24))
+- Added Rust (required for compiling sourmash from GitHub) ([#24](https://github.com/czbiohub/nf-predictorthologs/pull/24))
 - Added pandas=1.0.3, scikit-learn=0.22.1, and sourmash=3.2.2 to dependencies
 - Added subread=1.6.4 (featurecounts) and bioawk=1.0
 - Updated MultiQC to version 1.8 to avoid annoying YAML errors
 - Add ripgrep=12.0.1 ([faster than all other `grep`s](https://blog.burntsushi.net/ripgrep/)) to dependencies
+- Updated sourmash=3.3.0 ([#46](https://github.com/czbiohub/nf-predictorthologs/pull/46)) to support zip files as indices
 
 ### `Deprecated`

--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
   - pip=20.0.2
   - conda-forge::rust=1.41.0    # Required for building sourmash from source
   - conda-forge::scikit-learn=0.22.1
-  - bioconda::sourmash=3.2.2
+  - bioconda::sourmash=3.3.0
   - conda-forge::pandas=1.0.3
   - conda-forge::tqdm=4.45.0
   - thombashi::pathvalidate=2.2.0


### PR DESCRIPTION
This makes it easier to support pre-computed indices (https://github.com/czbiohub/nf-predictorthologs/issues/44) as the indices can now be zip files: http://ivory.idyll.org/blog/2020-sourmash-databases-as-zip-files.html which are easier to work with in nextflow than folders. (at least for me)


## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] Make sure your code lints (`nf-core lint .`).
- [x] `CHANGELOG.md` is updated
