### PR TITLE
Add Infernal for RNA search to dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,5 +34,6 @@ Initial release of nf-core/predictorthologs, created with the [nf-core](http://n
 - Add ripgrep=12.0.1 ([faster than all other `grep`s](https://blog.burntsushi.net/ripgrep/)) to dependencies
 - Updated sourmash=3.3.0 ([#46](https://github.com/czbiohub/nf-predictorthologs/pull/46)) to support zip files as indices
 - Added csvtk=0.20.0 to dependencies
+- Addeed infernal=1.1.2 to dependencies
 
 ### `Deprecated`

--- a/environment.yml
+++ b/environment.yml
@@ -35,5 +35,6 @@ dependencies:
   - bioawk=1.0
   - conda-forge::ripgrep=12.0.1
   - csvtk=0.20.0
+  - infernal=1.1.2
   - pip:
     - git+https://github.com/czbiohub/sencha.git@master#egg=sencha


### PR DESCRIPTION
Beginning of https://github.com/czbiohub/nf-predictorthologs/issues/22 

Adds latest version of infernal to the environment file

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated

