### PR TITLE
Update DIAMOND version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,5 +35,6 @@ Initial release of nf-core/predictorthologs, created with the [nf-core](http://n
 - Updated sourmash=3.3.0 ([#46](https://github.com/czbiohub/nf-predictorthologs/pull/46)) to support zip files as indices
 - Added csvtk=0.20.0 to dependencies
 - Addeed infernal=1.1.2 to dependencies
+- Update DIAMOND to version 0.9.35 to deal with new NCBI taxonomy formats
 
 ### `Deprecated`

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - conda-forge::r-markdown=1.1
   - conda-forge::r-base=3.6.1
   - bioconda::samtools=1.10
-  - bioconda::diamond=0.9.30
+  - bioconda::diamond=0.9.35
   - bioconda::fastp=0.20.0
   - bioconda::bedtools=2.29.2
   - pip=20.0.2


### PR DESCRIPTION
New NCBI `taxdmp.zip` is causing test failures in https://github.com/czbiohub/nf-predictorthologs/pull/54 due to the addition of the "strain" taxonomy:

References:
- http://www.diamondsearch.org/index.php?threads/v0-9-35-released.89/
- http://www.diamondsearch.org/index.php?threads/error-invalid-taxonomic-rank.86/

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] Make sure your code lints (`nf-core lint .`).
- [x] `CHANGELOG.md` is updated
