### PR TITLE
Phoenix/sambamba

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
         nxf_ver: ['19.10.0', '']
         profile_flags: [
         'test_bam',
+        'test_sambamba',
         'test_bam --search_noncoding',
         'test_diff_hash',
         'test_diff_hash --with_abundance',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Initial release of nf-core/predictorthologs, created with the [nf-core](http://n
 - Added option for `--input_is_protein`
 - Added option for `--differential_hash_expression` performed by scikit-learn's Logistic Regression
 - Added option of using sourmash to search instead of DIAMOND. This stays in hash-land by searching hashes (provided by `--hashes` or found by `--differential_hash_expression`) directly into a sourmash sequence bloom tree index database
+- Added option for bam deduplication, if you wish to skip deduplication step add the `-skip_remove_duplicates_bam` flag
 
 ### `Fixed`
 
@@ -36,5 +37,6 @@ Initial release of nf-core/predictorthologs, created with the [nf-core](http://n
 - Added csvtk=0.20.0 to dependencies
 - Addeed infernal=1.1.2 to dependencies
 - Update DIAMOND to version 0.9.35 to deal with new NCBI taxonomy formats
+- Added sambamba=0.7.1 using bioconda channel
 
 ### `Deprecated`

--- a/conf/test_sambamba.config
+++ b/conf/test_sambamba.config
@@ -1,0 +1,27 @@
+/*
+ * -------------------------------------------------------------------
+ *  Nextflow config file for running tests with sambamba
+ * -----------------------------------------------------------------------
+ * Defines bundled input files and everything required
+ * to run a fast and simple test. Use as follows:
+ *   nextflow run czbiohub/nf-predictorthologs -profile test_bam.config
+ */
+
+params {
+  config_profile_name = 'Test profile for sambamba'
+  config_profile_description = 'Minimal test dataset to check pipeline function for processes sambamba_dedup and sambamba_index'
+  // Limit resources so that this can run on Travis
+  max_cpus = 2
+  max_memory = 6.GB
+  max_time = 48.h
+  // Input data
+  bam = "https://github.com/czbiohub/test-datasets/raw/predictorthologs/testdata/SRR306792_GSM752645_ppy_br_M_1_1Aligned.sortedByCoord.out.ptprc_subset.bam"  
+  single_end = true
+  proteome_translate_fasta = 'https://raw.githubusercontent.com/czbiohub/test-datasets/predictorthologs/reference/ncbi_refseq_vertebrate_mammalian_ptprc_plus__np_only.fasta'
+  translate_peptide_molecule = 'dayhoff'
+  skip_remove_duplicates_bam = false
+  proteome_search_fasta = 'https://github.com/czbiohub/test-datasets/raw/predictorthologs/reference/ncbi_refseq_vertebrate_mammalian_ptprc_plus__np_only.fasta'
+  diamond_refseq_release = false
+  diamond_taxonmap_gz = "https://github.com/czbiohub/test-datasets/raw/predictorthologs/reference/prot.accession2taxid.vertebrate_mammalian_ptprc.with_header.txt.gz"
+
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,6 +16,7 @@
     - [`--single_end`](#-singleend)
     - [`--csv`](#-csv)
       - [Simple fasta input](#simple-fasta-input)
+      - [Bam input](#bam-input)
     - [Differential hash expression](#differential-hash-expression)
   - [Reference proteomes](#reference-proteomes)
     - [Proteomes for translating](#proteomes-for-translating)
@@ -171,6 +172,10 @@ sample_id,fasta
 sample1,sample1.fasta
 sample2,sample2.fasta
 ```
+
+#### Bam input
+
+Pipeline expects data in `.fastq` format. If using a bam instead you need to specify the `-bam` parameter. Bam deduplication is run by default with sambamba, if you wish to skip deduplication supply the `-skip_remove_duplicates_bam` flag. Deduplication is also skipped if `-bai` flag is specified with index file
 
 ### Differential hash expression
 

--- a/environment.yml
+++ b/environment.yml
@@ -17,6 +17,7 @@ dependencies:
   - conda-forge::r-markdown=1.1
   - conda-forge::r-base=3.6.1
   - bioconda::samtools=1.10
+  - bioconda::sambamba=0.7.1
   - bioconda::diamond=0.9.35
   - bioconda::fastp=0.20.0
   - bioconda::bedtools=2.29.2

--- a/nextflow.config
+++ b/nextflow.config
@@ -153,6 +153,7 @@ profiles {
   test_input_is_protein { includeConfig 'conf/test_input_is_protein.config' }
   test_csv { includeConfig 'conf/test_csv.config' }
   test_sourmash_search { includeConfig 'conf/test_sourmash_search.config' }
+  test_sambamba { includeConfig 'conf/test_sambamba.config' }
 }
 
 // Load igenomes.config if required


### PR DESCRIPTION
# nf-core/predictorthologs pull request

Added processes for `sambamba markdup` (deduplication) and `sambamba index` along with a `samtools view` option for if bed intervals are not provided.

closes #57 

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] Make sure your code lints (`nf-core lint .`).
- [x] Documentation in `docs` is updated
- [x] `CHANGELOG.md` is updated
- [x] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/predictorthologs/tree/master/.github/CONTRIBUTING.md)