### PR TITLE
fastp --trim_poly_x for paired end reads, too!

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on: [push, pull_request]
 
 jobs:
   test:
-    continue-on-error: []
     env:
       NXF_VER: ${{ matrix.nxf_ver }}
       NXF_ANSI_LOG: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
       NXF_RUN: "nextflow run -resume"
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
         # Nextflow versions: check pipeline minimum and current latest
         nxf_ver: ['19.10.0', '']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    continue-on-error: true
+    continue-on-error: []
     env:
       NXF_VER: ${{ matrix.nxf_ver }}
       NXF_ANSI_LOG: false
@@ -17,7 +17,20 @@ jobs:
         # Nextflow versions: check pipeline minimum and current latest
         nxf_ver: ['19.10.0', '']
         profile_flags: [
-        'test_download_refseq'
+        'test_bam',
+        'test_sambamba',
+        'test_bam --search_noncoding',
+        'test_diff_hash',
+        'test_diff_hash --with_abundance',
+        'test_diff_hash_sourmash',
+        'test_diff_hash_is_aligned',
+        'test_download_refseq',
+        'test_existing_database',
+        'test_fastq',
+        'test_fastq_paired',
+        'test_hash2kmer',
+        'test_input_is_protein',
+        'test_sourmash_search',
         ]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci_download_refseq.yml
+++ b/.github/workflows/ci_download_refseq.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    continue-on-error: []
+    continue-on-error: true
     env:
       NXF_VER: ${{ matrix.nxf_ver }}
       NXF_ANSI_LOG: false
@@ -17,19 +17,7 @@ jobs:
         # Nextflow versions: check pipeline minimum and current latest
         nxf_ver: ['19.10.0', '']
         profile_flags: [
-        'test_bam',
-        'test_sambamba',
-        'test_bam --search_noncoding',
-        'test_diff_hash',
-        'test_diff_hash --with_abundance',
-        'test_diff_hash_sourmash',
-        'test_diff_hash_is_aligned',
-        'test_download_refseq',
-        'test_existing_database',
-        'test_fastq',
-        'test_hash2kmer',
-        'test_input_is_protein',
-        'test_sourmash_search',
+        'test_download_refseq'
         ]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci_download_refseq.yml
+++ b/.github/workflows/ci_download_refseq.yml
@@ -14,7 +14,6 @@ jobs:
       NXF_RUN: "nextflow run -resume"
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
         # Nextflow versions: check pipeline minimum and current latest
         nxf_ver: ['19.10.0', '']

--- a/.github/workflows/ci_download_refseq.yml
+++ b/.github/workflows/ci_download_refseq.yml
@@ -1,4 +1,4 @@
-name: nf-core CI
+name: nf-core CI - download refseq (allowed to fail)
 # This workflow is triggered on pushes and PRs to the repository.
 # It runs the pipeline with the minimal test dataset to check that it completes without any syntax errors
 on: [push, pull_request]

--- a/.github/workflows/ci_download_refseq.yml
+++ b/.github/workflows/ci_download_refseq.yml
@@ -1,6 +1,8 @@
 name: nf-core CI - download refseq (allowed to fail)
 # This workflow is triggered on pushes and PRs to the repository.
-# It runs the pipeline with the minimal test dataset to check that it completes without any syntax errors
+# This workflow runs a test of downloading the proteome database "other" from
+# NCBI RefSeq but this often fails due to connection errors so this test is
+# separated out from the rest of ci.yml
 on: [push, pull_request]
 
 jobs:

--- a/.github/workflows/ci_download_refseq.yml
+++ b/.github/workflows/ci_download_refseq.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    continue-on-error: true
+    continue-on-error: []
     env:
       NXF_VER: ${{ matrix.nxf_ver }}
       NXF_ANSI_LOG: false
@@ -17,7 +17,19 @@ jobs:
         # Nextflow versions: check pipeline minimum and current latest
         nxf_ver: ['19.10.0', '']
         profile_flags: [
-        'test_download_refseq'
+        'test_bam',
+        'test_sambamba',
+        'test_bam --search_noncoding',
+        'test_diff_hash',
+        'test_diff_hash --with_abundance',
+        'test_diff_hash_sourmash',
+        'test_diff_hash_is_aligned',
+        'test_download_refseq',
+        'test_existing_database',
+        'test_fastq',
+        'test_hash2kmer',
+        'test_input_is_protein',
+        'test_sourmash_search',
         ]
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Initial release of nf-core/predictorthologs, created with the [nf-core](http://n
   - Output differential hash expression hashes and DIAMOND blastp search results into a per-group subfolder
   - Add `--with-abundance` flag to allow for differential expression with tracked abundances
 - `hash2kmer.py` ignores empty lines
+- Fixed polyX trimming for paired-end fastqs ([#66](https://github.com/czbiohub/nf-predictorthologs/pull/66))
 
 ### `Dependencies`
 

--- a/conf/test_fastq_paired.config
+++ b/conf/test_fastq_paired.config
@@ -1,0 +1,33 @@
+/*
+ * -------------------------------------------------
+ *  Nextflow config file for running tests
+ * -------------------------------------------------
+ * Defines bundled input files and everything required
+ * to run a fast and simple test. Use as follows:
+ *   nextflow run nf-core/predictorthologs -profile test,<docker/singularity>
+ */
+
+params {
+  config_profile_name = 'Test profile'
+  config_profile_description = 'Minimal test dataset to check pipeline function'
+  // Limit resources so that this can run on Travis
+  max_cpus = 2
+  max_memory = 6.GB
+  max_time = 48.h
+  // Input data
+
+  readPaths = [
+  ['SRR4050379', ['https://github.com/nf-core/test-datasets/raw/kmermaid/testdata/SRR4050379_pass_1.fastq.gz',
+                  'https://github.com/nf-core/test-datasets/raw/kmermaid/testdata/SRR4050379_pass_2.fastq.gz']],
+  ['SRR4050380', ['https://github.com/nf-core/test-datasets/raw/kmermaid/testdata/SRR4050380_pass_1.fastq.gz',
+                  'https://github.com/nf-core/test-datasets/raw/kmermaid/testdata/SRR4050380_pass_2.fastq.gz']]
+                  ]
+  single_end = false
+
+  proteome_translate_fasta = 'https://raw.githubusercontent.com/czbiohub/test-datasets/predictorthologs/reference/ncbi_refseq_vertebrate_mammalian_ptprc_plus__np_only.fasta'
+  translate_peptide_molecule = 'dayhoff'
+
+  proteome_search_fasta = 'https://github.com/czbiohub/test-datasets/raw/predictorthologs/reference/ncbi_refseq_vertebrate_mammalian_ptprc_plus__np_only.fasta'
+  diamond_taxonmap_gz = "https://github.com/czbiohub/test-datasets/raw/predictorthologs/reference/prot.accession2taxid.vertebrate_mammalian_ptprc.with_header.txt.gz"
+
+}

--- a/main.nf
+++ b/main.nf
@@ -812,7 +812,7 @@ if (!params.skip_trimming && !params.input_is_protein){
           """
           fastp \\
               --low_complexity_filter \\
-              --polyX \\
+              --trim_poly_x \\
               --in1 ${reads[0]} \\
               --in2 ${reads[1]} \\
               --out1 ${name}_R1_trimmed.fastq.gz \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -142,6 +142,7 @@ profiles {
     singularity.autoMounts = true
   }
   test_fastq { includeConfig 'conf/test_fastq.config' }
+  test_fastq_paired { includeConfig 'conf/test_fastq_paired.config' }
   test_bam { includeConfig 'conf/test_bam.config' }
   test_diff_hash { includeConfig 'conf/test_diff_hash.config' }
   test_diff_hash_abundance { includeConfig 'conf/test_diff_hash_abundance.config' }


### PR DESCRIPTION
This PR adds:

- A test for paired-end reads
- Fixes paired-end trimming for fastp
- Separates out the test for `test_download_refseq` into a separate `.github/workflows/ci_download_refseq.yml` file because it could take ~5 hours to fail due to connection issues, and the whole workflow would fail. This separates out that test into its own file that is allowed to fail on its own

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] Make sure your code lints (`nf-core lint .`).
- [ ] Documentation in `docs` is updated
- [x] `CHANGELOG.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/predictorthologs/tree/master/.github/CONTRIBUTING.md)