### PR TITLE
tokenized ksizes for sencha translate and sencha index

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on: [push, pull_request]
 
 jobs:
   test:
-    continue-on-error: []
     env:
       NXF_VER: ${{ matrix.nxf_ver }}
       NXF_ANSI_LOG: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
       NXF_RUN: "nextflow run -resume"
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
         # Nextflow versions: check pipeline minimum and current latest
         nxf_ver: ['19.10.0', '']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    continue-on-error: true
+    continue-on-error: []
     env:
       NXF_VER: ${{ matrix.nxf_ver }}
       NXF_ANSI_LOG: false
@@ -17,7 +17,20 @@ jobs:
         # Nextflow versions: check pipeline minimum and current latest
         nxf_ver: ['19.10.0', '']
         profile_flags: [
-        'test_download_refseq'
+        'test_bam',
+        'test_sambamba',
+        'test_bam --search_noncoding',
+        'test_diff_hash',
+        'test_diff_hash --with_abundance',
+        'test_diff_hash_sourmash',
+        'test_diff_hash_is_aligned',
+        'test_download_refseq',
+        'test_existing_database',
+        'test_fastq',
+        'test_fastq_paired',
+        'test_hash2kmer',
+        'test_input_is_protein',
+        'test_sourmash_search',
         ]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci_download_refseq.yml
+++ b/.github/workflows/ci_download_refseq.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    continue-on-error: []
+    continue-on-error: true
     env:
       NXF_VER: ${{ matrix.nxf_ver }}
       NXF_ANSI_LOG: false
@@ -17,19 +17,7 @@ jobs:
         # Nextflow versions: check pipeline minimum and current latest
         nxf_ver: ['19.10.0', '']
         profile_flags: [
-        'test_bam',
-        'test_sambamba',
-        'test_bam --search_noncoding',
-        'test_diff_hash',
-        'test_diff_hash --with_abundance',
-        'test_diff_hash_sourmash',
-        'test_diff_hash_is_aligned',
-        'test_download_refseq',
-        'test_existing_database',
-        'test_fastq',
-        'test_hash2kmer',
-        'test_input_is_protein',
-        'test_sourmash_search',
+        'test_download_refseq'
         ]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci_download_refseq.yml
+++ b/.github/workflows/ci_download_refseq.yml
@@ -14,7 +14,6 @@ jobs:
       NXF_RUN: "nextflow run -resume"
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
         # Nextflow versions: check pipeline minimum and current latest
         nxf_ver: ['19.10.0', '']

--- a/.github/workflows/ci_download_refseq.yml
+++ b/.github/workflows/ci_download_refseq.yml
@@ -1,4 +1,4 @@
-name: nf-core CI
+name: nf-core CI - download refseq (allowed to fail)
 # This workflow is triggered on pushes and PRs to the repository.
 # It runs the pipeline with the minimal test dataset to check that it completes without any syntax errors
 on: [push, pull_request]

--- a/.github/workflows/ci_download_refseq.yml
+++ b/.github/workflows/ci_download_refseq.yml
@@ -1,6 +1,8 @@
 name: nf-core CI - download refseq (allowed to fail)
 # This workflow is triggered on pushes and PRs to the repository.
-# It runs the pipeline with the minimal test dataset to check that it completes without any syntax errors
+# This workflow runs a test of downloading the proteome database "other" from
+# NCBI RefSeq but this often fails due to connection errors so this test is
+# separated out from the rest of ci.yml
 on: [push, pull_request]
 
 jobs:

--- a/.github/workflows/ci_download_refseq.yml
+++ b/.github/workflows/ci_download_refseq.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    continue-on-error: true
+    continue-on-error: []
     env:
       NXF_VER: ${{ matrix.nxf_ver }}
       NXF_ANSI_LOG: false
@@ -17,7 +17,19 @@ jobs:
         # Nextflow versions: check pipeline minimum and current latest
         nxf_ver: ['19.10.0', '']
         profile_flags: [
-        'test_download_refseq'
+        'test_bam',
+        'test_sambamba',
+        'test_bam --search_noncoding',
+        'test_diff_hash',
+        'test_diff_hash --with_abundance',
+        'test_diff_hash_sourmash',
+        'test_diff_hash_is_aligned',
+        'test_download_refseq',
+        'test_existing_database',
+        'test_fastq',
+        'test_hash2kmer',
+        'test_input_is_protein',
+        'test_sourmash_search',
         ]
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Initial release of nf-core/predictorthologs, created with the [nf-core](http://n
   - Output differential hash expression hashes and DIAMOND blastp search results into a per-group subfolder
   - Add `--with-abundance` flag to allow for differential expression with tracked abundances
 - `hash2kmer.py` ignores empty lines
+- Fixed polyX trimming for paired-end fastqs ([#66](https://github.com/czbiohub/nf-predictorthologs/pull/66))
 
 ### `Dependencies`
 

--- a/conf/test_fastq_paired.config
+++ b/conf/test_fastq_paired.config
@@ -1,0 +1,33 @@
+/*
+ * -------------------------------------------------
+ *  Nextflow config file for running tests
+ * -------------------------------------------------
+ * Defines bundled input files and everything required
+ * to run a fast and simple test. Use as follows:
+ *   nextflow run nf-core/predictorthologs -profile test,<docker/singularity>
+ */
+
+params {
+  config_profile_name = 'Test profile'
+  config_profile_description = 'Minimal test dataset to check pipeline function'
+  // Limit resources so that this can run on Travis
+  max_cpus = 2
+  max_memory = 6.GB
+  max_time = 48.h
+  // Input data
+
+  readPaths = [
+  ['SRR4050379', ['https://github.com/nf-core/test-datasets/raw/kmermaid/testdata/SRR4050379_pass_1.fastq.gz',
+                  'https://github.com/nf-core/test-datasets/raw/kmermaid/testdata/SRR4050379_pass_2.fastq.gz']],
+  ['SRR4050380', ['https://github.com/nf-core/test-datasets/raw/kmermaid/testdata/SRR4050380_pass_1.fastq.gz',
+                  'https://github.com/nf-core/test-datasets/raw/kmermaid/testdata/SRR4050380_pass_2.fastq.gz']]
+                  ]
+  single_end = false
+
+  proteome_translate_fasta = 'https://raw.githubusercontent.com/czbiohub/test-datasets/predictorthologs/reference/ncbi_refseq_vertebrate_mammalian_ptprc_plus__np_only.fasta'
+  translate_peptide_molecule = 'dayhoff'
+
+  proteome_search_fasta = 'https://github.com/czbiohub/test-datasets/raw/predictorthologs/reference/ncbi_refseq_vertebrate_mammalian_ptprc_plus__np_only.fasta'
+  diamond_taxonmap_gz = "https://github.com/czbiohub/test-datasets/raw/predictorthologs/reference/prot.accession2taxid.vertebrate_mammalian_ptprc.with_header.txt.gz"
+
+}

--- a/conf/test_sambamba.config
+++ b/conf/test_sambamba.config
@@ -18,7 +18,7 @@ params {
   bam = "https://github.com/czbiohub/test-datasets/raw/predictorthologs/testdata/SRR306792_GSM752645_ppy_br_M_1_1Aligned.sortedByCoord.out.ptprc_subset.bam"  
   single_end = true
   proteome_translate_fasta = 'https://raw.githubusercontent.com/czbiohub/test-datasets/predictorthologs/reference/ncbi_refseq_vertebrate_mammalian_ptprc_plus__np_only.fasta'
-  translate_peptide_molecule = 'dayhoff'
+  translate_peptide_molecule = 'dayhoff,protein'
   translate_peptide_ksize = '9,12'
   skip_remove_duplicates_bam = false
   proteome_search_fasta = 'https://github.com/czbiohub/test-datasets/raw/predictorthologs/reference/ncbi_refseq_vertebrate_mammalian_ptprc_plus__np_only.fasta'

--- a/conf/test_sambamba.config
+++ b/conf/test_sambamba.config
@@ -19,6 +19,7 @@ params {
   single_end = true
   proteome_translate_fasta = 'https://raw.githubusercontent.com/czbiohub/test-datasets/predictorthologs/reference/ncbi_refseq_vertebrate_mammalian_ptprc_plus__np_only.fasta'
   translate_peptide_molecule = 'dayhoff'
+  translate_peptide_ksize = '9,12'
   skip_remove_duplicates_bam = false
   proteome_search_fasta = 'https://github.com/czbiohub/test-datasets/raw/predictorthologs/reference/ncbi_refseq_vertebrate_mammalian_ptprc_plus__np_only.fasta'
   diamond_refseq_release = false

--- a/conf/test_sencha.config
+++ b/conf/test_sencha.config
@@ -1,6 +1,6 @@
 /*
  * -------------------------------------------------------------------
- *  Nextflow config file for running tests with sambamba
+ *  Nextflow config file for running tests for sench index and sencha translate
  * -----------------------------------------------------------------------
  * Defines bundled input files and everything required
  * to run a fast and simple test. Use as follows:
@@ -18,8 +18,8 @@ params {
   bam = "https://github.com/czbiohub/test-datasets/raw/predictorthologs/testdata/SRR306792_GSM752645_ppy_br_M_1_1Aligned.sortedByCoord.out.ptprc_subset.bam"  
   single_end = true
   proteome_translate_fasta = 'https://raw.githubusercontent.com/czbiohub/test-datasets/predictorthologs/reference/ncbi_refseq_vertebrate_mammalian_ptprc_plus__np_only.fasta'
-  translate_peptide_molecule = 'dayhoff'
-  translate_peptide_ksize = '9'
+  translate_peptide_molecule = 'dayhoff,protein'
+  translate_peptide_ksize = '9,12'
   skip_remove_duplicates_bam = false
   proteome_search_fasta = 'https://github.com/czbiohub/test-datasets/raw/predictorthologs/reference/ncbi_refseq_vertebrate_mammalian_ptprc_plus__np_only.fasta'
   diamond_refseq_release = false

--- a/main.nf
+++ b/main.nf
@@ -169,7 +169,7 @@ if (params.bam && params.bed && params.bai && !(params.reads || params.readPaths
     log.info "supplied bam and no skip_remove_duplicates flag specified"
     Channel.fromPath(params.bam)
         .ifEmpty { exit 1, "params.bam was empty, no input file supplied" }
-        .set { ch_bam_for_dedup }
+        .into { ch_bam_for_dedup }
 } else if (params.input_is_protein) {
   log.info 'Using protein fastas as input -- ignoring reads and bams'
   ////////////////////////////////////////////////////
@@ -629,7 +629,7 @@ if (params.bam && !params.skip_remove_duplicates_bam && !params.bai){
         publishDir "${params.outdir}/sambamba_dedup", mode: 'copy'
 
         input:
-        set file(bam) from ch_bam_for_dedup
+        file(bam) from ch_bam_for_dedup
 
         output:
         set val(prefix), file(bam_dedup) into ch_dedup_bam_for_index, ch_dedup_bam_for_samtools_fastq
@@ -653,7 +653,7 @@ if (params.bam && !params.skip_remove_duplicates_bam && !params.bai){
         set val(bam_name), file(bam_dedup) from ch_dedup_bam_for_index
 
         output:
-        set file(bai_dedup) into ch_dedup_bai
+        file(bai_dedup) into ch_dedup_bai
 
         script:
         bai_dedup = "${bam_name}.bai"

--- a/main.nf
+++ b/main.nf
@@ -460,7 +460,7 @@ if (params.infernal_db) {
 //////////////////////////////////////////////////////////////////
 /* -     Parse translate and diamond parameters         -- */
 //////////////////////////////////////////////////////////////////
-peptide_ksize = params.translate_peptide_ksize
+peptide_ksize = params.translate_peptide_ksize?.toString().tokenize(',')
 peptide_molecule = params.translate_peptide_molecule
 jaccard_threshold = params.translate_jaccard_threshold
 refseq_release = params.refseq_release
@@ -861,17 +861,18 @@ if (!params.input_is_protein && params.protein_searcher == 'diamond'){
     input:
     file(peptides) from ch_proteome_translate_fasta
     each molecule from peptide_molecule
+    each ksize from peptide_ksize
 
     output:
-    set val(bloom_id), val(molecule), file("${peptides.simpleName}__${bloom_id}.bloomfilter") into ch_sencha_bloom_filters
+        set val(bloom_id), val(molecule), file("${peptides.simpleName}__${bloom_id}.bloomfilter"), val(ksize) into ch_sencha_bloom_filters
 
     script:
-    bloom_id = "molecule-${molecule}_ksize-${peptide_ksize}"
+    bloom_id = "molecule-${molecule}_ksize-${ksize}"
     """
     sencha index \\
       --tablesize ${tablesize} \\
       --molecule ${molecule} \\
-      --peptide-ksize ${peptide_ksize} \\
+      --peptide-ksize ${ksize} \\
       --save-as ${peptides.simpleName}__${bloom_id}.bloomfilter \\
       ${peptides}
     """
@@ -879,7 +880,7 @@ if (!params.input_is_protein && params.protein_searcher == 'diamond'){
 
   // From Paolo - how to do translate on ALL combinations of bloom filters
    ch_sencha_bloom_filters
-    .groupTuple(by: [0, 3])
+        .groupTuple(by: [0, 3])
       .combine(ch_reads_trimmed_nonempty)
     .set{ ch_sencha_bloom_filters_grouptuple }
 
@@ -901,10 +902,10 @@ if (!params.input_is_protein && params.protein_searcher == 'diamond'){
 
     input:
     tuple \
-      val(bloom_id), val(alphabet), file(bloom_filter), \
-      val(sample_id), file(reads) \
+        val(bloom_id), val(alphabet), file(bloom_filter), val(ksize), \
+        val(sample_id), file(reads) \
         from ch_sencha_bloom_filters_grouptuple
-
+    
     output:
     // TODO also extract nucleotide sequence of coding reads and do sourmash compute using only DNA on that?
     set val(sample_id), file("${sample_id}__noncoding_reads_nucleotides.fasta") into ch_noncoding_nucleotides_potentially_empty
@@ -918,7 +919,7 @@ if (!params.input_is_protein && params.protein_searcher == 'diamond'){
     """
     sencha translate \\
       --molecule ${alphabet[0]} \\
-      --peptide-ksize ${peptide_ksize} \\
+      --peptide-ksize ${ksize} \\
       --jaccard-threshold ${jaccard_threshold} \\
       --noncoding-nucleotide-fasta ${sample_id}__noncoding_reads_nucleotides.fasta \\
       --coding-nucleotide-fasta ${sample_id}__coding_reads_nucleotides.fasta \\

--- a/main.nf
+++ b/main.nf
@@ -461,7 +461,7 @@ if (params.infernal_db) {
 /* -     Parse translate and diamond parameters         -- */
 //////////////////////////////////////////////////////////////////
 peptide_ksize = params.translate_peptide_ksize?.toString().tokenize(',')
-peptide_molecule = params.translate_peptide_molecule
+peptide_molecule = params.translate_peptide_molecule?.toString().tokenize(',')
 jaccard_threshold = params.translate_jaccard_threshold
 refseq_release = params.refseq_release
 tablesize = params.translate_tablesize

--- a/main.nf
+++ b/main.nf
@@ -812,7 +812,7 @@ if (!params.skip_trimming && !params.input_is_protein){
           """
           fastp \\
               --low_complexity_filter \\
-              --polyX \\
+              --trim_poly_x \\
               --in1 ${reads[0]} \\
               --in2 ${reads[1]} \\
               --out1 ${name}_R1_trimmed.fastq.gz \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -142,6 +142,7 @@ profiles {
     singularity.autoMounts = true
   }
   test_fastq { includeConfig 'conf/test_fastq.config' }
+  test_fastq_paired { includeConfig 'conf/test_fastq_paired.config' }
   test_bam { includeConfig 'conf/test_bam.config' }
   test_diff_hash { includeConfig 'conf/test_diff_hash.config' }
   test_diff_hash_abundance { includeConfig 'conf/test_diff_hash_abundance.config' }

--- a/nextflow.config
+++ b/nextflow.config
@@ -154,6 +154,7 @@ profiles {
   test_csv { includeConfig 'conf/test_csv.config' }
   test_sourmash_search { includeConfig 'conf/test_sourmash_search.config' }
   test_sambamba { includeConfig 'conf/test_sambamba.config' }
+  test_sencha { includeConfig 'conf/test_sencha.config'}
 }
 
 // Load igenomes.config if required


### PR DESCRIPTION
# nf-core/predictorthologs pull request

i was getting some errors when running on the bat data because the ksizes weren't being properly tokenized and were instead being processed as strings, this is my fix. I updated test_sambamba config to test the new input peptide ksize and params.translate_peptide_molecule. 

closes issue #67 