### PR TITLE
Don't filter reads for size after trimming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Initial release of nf-core/predictorthologs, created with the [nf-core](http://n
   - Add `--with-abundance` flag to allow for differential expression with tracked abundances
 - `hash2kmer.py` ignores empty lines
 - Fixed polyX trimming for paired-end fastqs ([#66](https://github.com/czbiohub/nf-predictorthologs/pull/66))
+- Fixed paired-end reads getting removed after trimming ([#75](https://github.com/czbiohub/nf-predictorthologs/pull/75))
 
 ### `Dependencies`
 

--- a/main.nf
+++ b/main.nf
@@ -826,7 +826,7 @@ if (!params.skip_trimming && !params.input_is_protein){
   // filter out empty fastq files
   ch_reads_trimmed
       // gzipped files are 20 bytes when empty
-      .filter{ it[1].size() > 20 }
+      // .filter{ it[1].size() > 20 }
       .set { ch_reads_trimmed_nonempty }
 } else if (!params.input_is_protein) {
   ch_reads_trimmed_nonempty = ch_read_files_trimming
@@ -859,7 +859,7 @@ if (!params.input_is_protein && params.protein_searcher == 'diamond'){
     each ksize from peptide_ksize
 
     output:
-        set val(bloom_id), val(molecule),  val(ksize), file("${peptides.simpleName}__${bloom_id}.bloomfilter") into ch_sencha_bloom_filters
+    set val(bloom_id), val(molecule),  val(ksize), file("${peptides.simpleName}__${bloom_id}.bloomfilter") into ch_sencha_bloom_filters
 
     script:
     bloom_id = "molecule-${molecule}_ksize-${ksize}"

--- a/main.nf
+++ b/main.nf
@@ -825,13 +825,8 @@ if (!params.skip_trimming && !params.input_is_protein){
         """
       }
   }
-  // filter out empty fastq files
-  ch_reads_trimmed
-      // gzipped files are 20 bytes when empty
-      // .filter{ it[1].size() > 20 }
-      .set { ch_reads_trimmed_nonempty }
 } else if (!params.input_is_protein) {
-  ch_reads_trimmed_nonempty = ch_read_files_trimming
+  ch_reads_trimmed = ch_read_files_trimming
 } else {
   ch_fastp_results = Channel.empty()
 }
@@ -878,7 +873,7 @@ if (!params.input_is_protein && params.protein_searcher == 'diamond'){
   // From Paolo - how to do translate on ALL combinations of bloom filters
    ch_sencha_bloom_filters
       .groupTuple(by: [0, 1, 2])
-      .combine(ch_reads_trimmed_nonempty)
+      .combine(ch_reads_trimmed)
       .dump( tag: 'ch_sencha_bloom_filters_grouptuple' )
       // [DUMP: ch_sencha_bloom_filters_grouptuple]
       //    [molecule-protein_ksize-12,


### PR DESCRIPTION
For paired-end reads, the read size filtering was removing all reads since the length was less than 20

@lekhakaranam try using this branch 

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the [nf-core/predictorthologs branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/predictorthologs)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Documentation in `docs` is updated
- [ ] `CHANGELOG.md` is updated
- [ ] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/predictorthologs/tree/master/.github/CONTRIBUTING.md)