### PR TITLE
Propagate molecule and k-mer size to sample id in sencha translate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Initial release of nf-core/predictorthologs, created with the [nf-core](http://n
 - Added option for `--differential_hash_expression` performed by scikit-learn's Logistic Regression
 - Added option of using sourmash to search instead of DIAMOND. This stays in hash-land by searching hashes (provided by `--hashes` or found by `--differential_hash_expression`) directly into a sourmash sequence bloom tree index database
 - Added option for bam deduplication, if you wish to skip deduplication step add the `-skip_remove_duplicates_bam` flag
+- Added ability to search DIAMOND for hashes that were unassigned from sourmash ([#79](https://github.com/czbiohub/nf-predictorthologs/pull/79))
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Initial release of nf-core/predictorthologs, created with the [nf-core](http://n
 - Fixed paired-end reads getting removed after trimming ([#75](https://github.com/czbiohub/nf-predictorthologs/pull/75))
 - Fixed number of cpus, memory, time requirements for sambamba processes ([#76](https://github.com/czbiohub/nf-predictorthologs/pull/76))
 - Fixed noncoding search to use `cmscan` instead of `cmsearch` from INFERNAL ([#74](https://github.com/czbiohub/nf-predictorthologs/pull/74))
+- Propagate molecule and k-mer size to sample id after translate
 
 ### `Dependencies`
 

--- a/main.nf
+++ b/main.nf
@@ -917,18 +917,18 @@ if (!params.input_is_protein && params.protein_searcher == 'diamond'){
     // TODO also extract nucleotide sequence of coding reads and do sourmash compute using only DNA on that?
     set val(sample_sketch_id), file(noncoding_nucleotides) into ch_noncoding_nucleotides_potentially_empty
     // Set first value to "false" so it's not treated as a differential hash, and only the sample_id is considered
-    set val(false), val(sample_sketch_id), file(peptides) into ch_translated_proteins_potentially_empty
+    set val(false), val(sample_sketch_id), file(peptides_fasta) into ch_translated_proteins_potentially_empty
     set val(sample_sketch_id), file(coding_nucleotides) into ch_coding_nucleotides
     set val(sample_sketch_id), file(coding_scores) into ch_coding_scores_csv
-    set val(sample_sketch_id), file(summary) into ch_coding_scores_json
+    set val(sample_sketch_id), file(summary_json) into ch_coding_scores_json
 
     script:
     sample_sketch_id = "${sample_id}__${bloom_id}"
     noncoding_nucleotides = "${sample_sketch_id}__noncoding_reads_nucleotides.fasta"
     coding_nucleotides = "${sample_sketch_id}__coding_reads_nucleotides.fasta"
-    peptides = "${sample_sketch_id}__coding_reads_peptides.fasta"
+    peptides_fasta = "${sample_sketch_id}__coding_reads_peptides.fasta"
     coding_scores = "${sample_sketch_id}__coding_scores.csv"
-    summary = "${sample_sketch_id}__coding_summary.json"
+    summary_json = "${sample_sketch_id}__coding_summary.json"
     """
     sencha translate \\
       --molecule ${alphabet} \\
@@ -937,10 +937,10 @@ if (!params.input_is_protein && params.protein_searcher == 'diamond'){
       --noncoding-nucleotide-fasta ${noncoding_nucleotides} \\
       --coding-nucleotide-fasta ${coding_nucleotides} \\
       --csv ${coding_scores} \\
-      --json-summary ${summary} \\
+      --json-summary ${summary_json} \\
       --peptides-are-bloom-filter \\
       ${bloom_filter} \\
-      ${reads} > ${peptides}
+      ${reads} > ${peptides_fasta}
     """
   }
 

--- a/main.nf
+++ b/main.nf
@@ -905,7 +905,7 @@ if (!params.input_is_protein && params.protein_searcher == 'diamond'){
   process translate {
     tag "${sample_sketch_id}"
     label "process_long"
-    publishDir "${params.outdir}/translate/", mode: 'copy'
+    publishDir "${params.outdir}/translate/${bloom_id}", mode: 'copy'
 
     input:
     tuple \


### PR DESCRIPTION
When adding the multiplexed molecule and ksize to `sencha translate` (#69, #72), the sample ID was not updated, so all the files from the same original sample, but different molecules and ksizes get overwritten to the same file. This fixes that.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the [nf-core/predictorthologs branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/predictorthologs)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Documentation in `docs` is updated
- [x] `CHANGELOG.md` is updated
- [ ] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/predictorthologs/tree/master/.github/CONTRIBUTING.md)